### PR TITLE
Delegate actions to subagents, keep main thread clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ What's new, what's better, what's different. Most recent stuff on top.
 
 ---
 
+## 0.11.0 — The Delegate (2026-02-24)
+
+Actions now run in subagents instead of the main context window. The 170-220KB of action file content that used to flood the conversation stays out of sight — the main thread only handles routing and receives a summary. `work` and `cleanup` run in the background so you get your conversation back immediately.
+
+- Replaced "Action References" with "Action Dispatch" in SKILL.md
+- Actions dispatched to `general-purpose` Task subagents via prompt pattern
+- `work` and `cleanup` run in background (non-blocking)
+- `do`, `verify`, `version` run in foreground (blocking)
+- Screenshots bridged to `do` subagent via temp files + text descriptions
+
 ## 0.10.0 — The Hard Stop (2026-02-16)
 
 Capture no longer slides into execution. The do action now has an explicit boundary: after writing files and reporting back, it stops. No helpful "let me go ahead and start building that for you." The user decides when to run the queue — always. Both SKILL.md (routing level) and do.md (action level) enforce this, so even eager agents get the message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ What's new, what's better, what's different. Most recent stuff on top.
 
 ---
 
+## 0.11.1 — The Safety Net (2026-02-24)
+
+Subagent dispatch no longer assumes subagents exist. Environments without Task subagents can now fall back to reading the action file directly in the current session — no more broken routing in simpler tools. The dispatch section is restructured as "if available / if not" so the skill stays portable.
+
+- Added fallback path: read action file directly when subagents are unavailable
+- Removed Claude Code-specific language (Task tool, `run_in_background`)
+- Dispatch table simplified — background column moved into subagent-specific guidance
+
 ## 0.11.0 — The Delegate (2026-02-24)
 
 Actions now run in subagents instead of the main context window. The 170-220KB of action file content that used to flood the conversation stays out of sight — the main thread only handles routing and receives a summary. `work` and `cleanup` run in the background so you get your conversation back immediately.

--- a/actions/version.md
+++ b/actions/version.md
@@ -2,7 +2,7 @@
 
 > **Part of the do-work skill.** Handles version reporting and update checks.
 
-**Current version**: 0.11.0
+**Current version**: 0.11.1
 
 **Upstream**: https://raw.githubusercontent.com/bladnman/do-work/main/actions/version.md
 

--- a/actions/version.md
+++ b/actions/version.md
@@ -2,7 +2,7 @@
 
 > **Part of the do-work skill.** Handles version reporting and update checks.
 
-**Current version**: 0.10.0
+**Current version**: 0.11.0
 
 **Upstream**: https://raw.githubusercontent.com/bladnman/do-work/main/actions/version.md
 


### PR DESCRIPTION
## TL;DR
I'd like /do-work run to use background tasks, each with their own fresh context, so the main thread doesn't get filled up.

## Summary
Refactor action execution to run in `general-purpose` Task subagents instead of the main conversation context. This keeps the 170-220KB of action file content out of the main thread, which only handles routing decisions and receives brief summaries.

## Key Changes
- **Replaced "Action References" with "Action Dispatch"** in SKILL.md with a new execution model
- **Introduced subagent dispatch pattern**: Actions are read and executed by subagents via prompt instructions, with `$ARGUMENTS` passed as user input
- **Background vs. foreground execution**: 
  - `work` and `cleanup` run with `run_in_background: true` for non-blocking execution
  - `do`, `verify`, `version` run blocking (foreground) for immediate user interaction
- **Screenshot bridging**: Before dispatching the `do` action, screenshots are saved to temp files with text descriptions and included in the subagent prompt (subagents can't see images from main conversation)
- **Error handling**: Failures are reported to the user without re-execution in the main thread
- **Updated version** to 0.11.0 in both CHANGELOG.md and actions/version.md

## Implementation Details
- Added a reference table in SKILL.md showing each action's file path, background status, and required context
- Clarified that background actions print a status line and return control immediately, with results delivered asynchronously
- Documented the screenshot handling workaround with specific file naming convention (`screenshot-{n}.png`)

https://claude.ai/code/session_016fAx2ahtkBYTrKdfjXmyQB